### PR TITLE
hotfix for enabling comments on docs

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -79,6 +79,16 @@ class BP_Docs_Admin {
 		);
 		register_setting( 'bp-docs-settings', 'bp-docs-excerpt-length', 'absint' );
 
+		// General - Enable Comments
+		add_settings_field(
+			'bp-docs-enable-comments',
+			__( 'Enable Comments', 'bp-docs' ),
+			array( $this, 'enable_comments_setting_markup' ),
+			'bp-docs-settings',
+			'bp-docs-general'
+		);
+		register_setting( 'bp-docs-settings', 'bp-docs-enable-comments', 'absint' );
+
 		// Users
 		add_settings_section(
 			'bp-docs-users',
@@ -179,6 +189,17 @@ class BP_Docs_Admin {
 		?>
 		<input name="bp-docs-excerpt-length" id="bp-docs-excerpt-length" type="text" value="<?php echo esc_html( $length ) ?>" />
 		<p class="description"><?php _e( "Excerpts are shown on Docs directories, to provide better context. If your theme or language requires longer or shorter excerpts, change this value. Set to <code>0</code> to disable these excerpts.", 'bp-docs' ) ?></p>
+
+		<?php
+	}
+
+	public function enable_comments_setting_markup() {
+
+		$comments_enabled = bp_docs_get_setting_comments_enabled(); 
+
+		?>
+			<input name="bp-docs-enable-comments" id="bp-docs-enable-comments" type="checkbox" value="1" <?php checked( $comments_enabled ); ?> />
+		<p class="description"><?php _e( "Allow people to post comments on new docs? This will override your WordPress comments setting.", 'bp-docs' ) ?></p>
 
 		<?php
 	}

--- a/includes/query-builder.php
+++ b/includes/query-builder.php
@@ -464,7 +464,8 @@ class BP_Docs_Query {
 				'post_title'   => $_POST['doc']['title'],
 				'post_name'    => isset( $_POST['doc']['permalink'] ) ? sanitize_title( $_POST['doc']['permalink'] ) : sanitize_title( $_POST['doc']['title'] ),
 				'post_content' => sanitize_post_field( 'post_content', $doc_content, 0, 'db' ),
-				'post_status'  => 'publish'
+				'post_status'  => 'publish',
+				'comment_status' => ( ( bp_docs_get_setting_comments_enabled() )  ? 'open' : 'closed' ), 
 			);
 
 			$r = wp_parse_args( $args, $defaults );

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -1249,6 +1249,27 @@ function bp_docs_get_docs_slug() {
 	return apply_filters( 'bp_docs_get_docs_slug', $slug );
 }
 
+/* 
+ * Gets the setting "Enable Comments" 
+ */ 
+function bp_docs_get_setting_comments_enabled() {
+	global $bp;
+
+	$enable_comments = get_option( 'bp-docs-enable-comments' );
+	_log( "option 'bp-docs-enable-comments':" ); 
+	_log( $enable_comments ); 
+
+	// Default is enabled. 
+	if ( ! isset( $enable_comments ) ) {
+		$enable_comments = 1;
+	}
+
+	_log( "option 'bp-docs-enable-comments' is now:" ); 
+	_log( $enable_comments ); 
+
+	return apply_filters( 'bp_docs_get_setting_comments_enabled', $enable_comments );
+}
+
 /**
  * Outputs the tabs at the top of the Docs view (All Docs, New Doc, etc)
  *

--- a/includes/templatetags.php
+++ b/includes/templatetags.php
@@ -1256,16 +1256,11 @@ function bp_docs_get_setting_comments_enabled() {
 	global $bp;
 
 	$enable_comments = get_option( 'bp-docs-enable-comments' );
-	_log( "option 'bp-docs-enable-comments':" ); 
-	_log( $enable_comments ); 
 
 	// Default is enabled. 
 	if ( ! isset( $enable_comments ) ) {
 		$enable_comments = 1;
 	}
-
-	_log( "option 'bp-docs-enable-comments' is now:" ); 
-	_log( $enable_comments ); 
 
 	return apply_filters( 'bp_docs_get_setting_comments_enabled', $enable_comments );
 }


### PR DESCRIPTION
This is a fix for issue mlaa/cbox-mla#224, which is best described upstream at boonebgorges/buddypress-docs#440. It adds an option for enabling commenting on docs, overriding the WP global commenting option. 